### PR TITLE
Improve Windows experience with USERPROFILE env

### DIFF
--- a/lib/kubeconfig.ts
+++ b/lib/kubeconfig.ts
@@ -26,7 +26,7 @@ export class KubeConfig {
 
     if (!path) {
       // default file is ignored if it't not found
-      const defaultPath = join(Deno.env.get("HOME") || "/root", ".kube", "config");
+      const defaultPath = join(Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "/root", ".kube", "config");
       try {
         return await KubeConfig.readFromPath(defaultPath);
       } catch (err) {


### PR DESCRIPTION
On windows, the HOME environment variable is not generally set. Instead, the variable USERPROFILE points to the user's home directory where the .kube/config will be located