### PR TITLE
Introduce an API to establish channels

### DIFF
--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -21,7 +21,7 @@ export interface RequestOptions {
   bodyStream?: ReadableStream<Uint8Array>;
 
   accept?: string;
-  expectChannel?: string[];
+  expectTunnel?: string[];
   expectStream?: boolean;
   expectJson?: boolean;
 }
@@ -54,7 +54,7 @@ export interface ChannelTunnel {
 }
 
 export interface RestClient {
-  performRequest(opts: RequestOptions & {expectChannel: string[]}): Promise<ChannelTunnel>;
+  performRequest(opts: RequestOptions & {expectTunnel: string[]}): Promise<ChannelTunnel>;
   performRequest(opts: RequestOptions & {expectStream: true; expectJson: true}): Promise<ReadableStream<JSONValue>>;
   performRequest(opts: RequestOptions & {expectStream: true}): Promise<ReadableStream<Uint8Array>>;
   performRequest(opts: RequestOptions & {expectJson: true}): Promise<JSONValue>;

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -26,11 +26,11 @@ export interface RequestOptions {
   expectJson?: boolean;
 }
 
-export interface KubernetesTunnel {
+export interface KubernetesTunnel<Tproto extends string> {
   /** Indicates which network protocol is in use.
    * This changes semantics, largely due to Kubernetes tunnel API quirks. */
   readonly transportProtocol: 'SPDY' | 'WebSocket' | 'Opaque';
-  readonly subProtocol: string;
+  readonly subProtocol: Tproto;
   /** Set up a channel, using either SPDY or Websocket semantics. */
   getChannel<
     Treadable extends boolean,
@@ -49,11 +49,11 @@ export interface KubernetesTunnel {
   /** Call once after creating the initial channels. */
   ready(): Promise<void>;
   /** Disconnects the underlying transport. */
-  disconnect(): Promise<void>;
+  stop(): Promise<void>;
 }
 
 export interface RestClient {
-  performRequest(opts: RequestOptions & {expectTunnel: string[]}): Promise<KubernetesTunnel>;
+  performRequest<Tproto extends string>(opts: RequestOptions & {expectTunnel: Tproto[]}): Promise<KubernetesTunnel<Tproto>>;
   performRequest(opts: RequestOptions & {expectStream: true; expectJson: true}): Promise<ReadableStream<JSONValue>>;
   performRequest(opts: RequestOptions & {expectStream: true}): Promise<ReadableStream<Uint8Array>>;
   performRequest(opts: RequestOptions & {expectJson: true}): Promise<JSONValue>;

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -26,7 +26,7 @@ export interface RequestOptions {
   expectJson?: boolean;
 }
 
-export interface ChannelTunnel {
+export interface KubernetesTunnel {
   /** Indicates which network protocol is in use.
    * This changes semantics, largely due to Kubernetes tunnel API quirks. */
   readonly transportProtocol: 'SPDY' | 'WebSocket' | 'Opaque';
@@ -43,7 +43,7 @@ export interface ChannelTunnel {
     readable: Treadable;
     writable: Twritable;
   }): Promise<{
-    close(): Promise<void>;
+    // close(): Promise<void>;
     readable: Treadable extends true ? ReadableStream<Uint8Array> : null;
     writable: Twritable extends true ? WritableStream<Uint8Array> : null;
   }>;
@@ -54,7 +54,7 @@ export interface ChannelTunnel {
 }
 
 export interface RestClient {
-  performRequest(opts: RequestOptions & {expectTunnel: string[]}): Promise<ChannelTunnel>;
+  performRequest(opts: RequestOptions & {expectTunnel: string[]}): Promise<KubernetesTunnel>;
   performRequest(opts: RequestOptions & {expectStream: true; expectJson: true}): Promise<ReadableStream<JSONValue>>;
   performRequest(opts: RequestOptions & {expectStream: true}): Promise<ReadableStream<Uint8Array>>;
   performRequest(opts: RequestOptions & {expectJson: true}): Promise<JSONValue>;

--- a/lib/contract.ts
+++ b/lib/contract.ts
@@ -43,7 +43,6 @@ export interface KubernetesTunnel {
     readable: Treadable;
     writable: Twritable;
   }): Promise<{
-    // close(): Promise<void>;
     readable: Treadable extends true ? ReadableStream<Uint8Array> : null;
     writable: Twritable extends true ? WritableStream<Uint8Array> : null;
   }>;

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -103,7 +103,7 @@ export class KubeConfigRestClient implements RestClient {
       console.error(opts.method, path);
     }
 
-    if (opts.expectChannel) throw new Error(
+    if (opts.expectTunnel) throw new Error(
       `Channel-based APIs are not currently implemented by this client.`);
 
     const headers: Record<string, string> = {};

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -103,6 +103,9 @@ export class KubeConfigRestClient implements RestClient {
       console.error(opts.method, path);
     }
 
+    if (opts.expectChannel) throw new Error(
+      `Channel-based APIs are not currently implemented by this client.`);
+
     const headers: Record<string, string> = {};
 
     if (!this.ctx.cluster.server) throw new Error(`No server URL found in KubeConfig`);

--- a/transports/via-kubectl-raw.ts
+++ b/transports/via-kubectl-raw.ts
@@ -108,7 +108,7 @@ export class KubectlRawRestClient implements RestClient {
     const hasReqBody = opts.bodyJson !== undefined || !!opts.bodyRaw || !!opts.bodyStream;
     isVerbose && console.error(opts.method, path, hasReqBody ? '(w/ body)' : '');
 
-    if (opts.expectChannel) throw new Error(
+    if (opts.expectTunnel) throw new Error(
       `Channel-based APIs are not currently implemented by this client.`);
 
     let rawArgs = [command, ...(hasReqBody ? ['-f', '-'] : []), "--raw", path];

--- a/transports/via-kubectl-raw.ts
+++ b/transports/via-kubectl-raw.ts
@@ -108,6 +108,9 @@ export class KubectlRawRestClient implements RestClient {
     const hasReqBody = opts.bodyJson !== undefined || !!opts.bodyRaw || !!opts.bodyStream;
     isVerbose && console.error(opts.method, path, hasReqBody ? '(w/ body)' : '');
 
+    if (opts.expectChannel) throw new Error(
+      `Channel-based APIs are not currently implemented by this client.`);
+
     let rawArgs = [command, ...(hasReqBody ? ['-f', '-'] : []), "--raw", path];
 
     if (command === 'patch') {


### PR DESCRIPTION
My goal here is to describe Kubernetes tunneling in a generic way so that it is valid for both types of tunnel transport supported by Kubernetes (SPDY/3.1 and Websockets).

Unfortunately, the two transports are given different semantics by Kubernetes.
* The port-forward API notably doesn't allow creating proxying further TCP sockets after a Websocket is already  open, so SPDY is superior for port-forward usecases.
* The exec/attach API doesn't allow closing stdin, and thus telling a program when we're done giving it data, though this is being proposed for a future subprotocol (v5).
* There is a binary-log WebSocket API as well, which doesn't have the stream-multiplexing semantics and is actually just a raw bytestream. There is no SPDY version of this subprotocol. This seems to exist purely to allow binary-safe pod log fetches. I'm uh, I'm not really worrying about this one.

Related:

* #14 
* #6 
* #3
* https://github.com/cloudydeno/deno-kubernetes_apis/issues/2