### PR TITLE
Green the CI, Require Deno v1.41+

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -13,12 +13,8 @@ jobs:
     strategy:
       matrix:
         deno-version:
-        - v1.28
-        - v1.30
-        - v1.32
-        - v1.35
-        - v1.39
-        - v1.40
+        - v1.41
+        - v1.43
         - v1.45
         - canary
       fail-fast: false # run each branch to completion
@@ -46,34 +42,6 @@ jobs:
 
     - name: Check demo.ts
       run: time deno check --unstable demo.ts
-
-  check-unstable:
-    runs-on: ubuntu-latest
-    name: Check Unstable w/ ${{ matrix.deno-version }}
-    strategy:
-      matrix:
-        deno-version:
-        - v1.39
-        - canary
-      fail-fast: false # run each branch to completion
-
-    steps:
-    - name: Checkout source
-      uses: actions/checkout@v4
-
-    - name: Use Deno ${{ matrix.deno-version }}
-      uses: denoland/setup-deno@v1
-      with:
-        deno-version: ${{ matrix.deno-version }}
-
-    # "https" cache: code from the Internet
-    # External sources won't change much so we use less precise keys
-    - name: Cache https://
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/deno/deps/https
-        key: deno-https/v1-${{ github.sha }}
-        restore-keys: deno-https/v1-
 
     - name: Check tunnel-beta/examples/ws-exec-poc.ts
       run: time deno check --unstable tunnel-beta/examples/ws-exec-poc.ts

--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -18,6 +18,8 @@ jobs:
         - v1.32
         - v1.35
         - v1.39
+        - v1.40
+        - v1.45
         - canary
       fail-fast: false # run each branch to completion
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Check out `lib/contract.ts` to see the type/API contract.
 
 ## Changelog
 
-
 * `v0.7.0` on `2023-08-13`:
     Port `KubectlRawRestClient` over to newer `Deno.Command()` API.
     Support patching subresources & opening PodExec tunnels in `KubectlRawRestClient`.
@@ -61,6 +60,7 @@ Check out `lib/contract.ts` to see the type/API contract.
 
     * `v0.7.1` on `2023-09-24`: Update std dependencies to `/std@0.202.0`
     * `v0.7.2` on `2023-12-29`: Fix `WebsocketTunnel` for Deno v1.38 change
+    * `v0.7.3` on `2024-09-10`: Drop support for Deno v1.40 and earlier.
 
 * `v0.6.0` on `2023-08-08`:
     Introduce an API for opening Kubernetes tunnels, useful for `PodExec` and others.

--- a/lib/kubeconfig.ts
+++ b/lib/kubeconfig.ts
@@ -28,8 +28,8 @@ export class KubeConfig {
       const defaultPath = joinPath(Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "/root", ".kube", "config");
       try {
         return await KubeConfig.readFromPath(defaultPath);
-      } catch (err) {
-        if (err.name === 'NotFound') {
+      } catch (err: unknown) {
+        if ((err as Error).name === 'NotFound') {
           return new KubeConfig(mergeKubeConfigs([]));
         }
         throw err;
@@ -221,7 +221,7 @@ export class KubeConfigContext {
     const execConfig = this.user['exec'];
     if (!execConfig) throw new Error(`BUG: execConfig disappeared`);
 
-    const isTTY = Deno.isatty(Deno.stdin.rid);
+    const isTTY = Deno.stdin.isTerminal();
     const stdinPolicy = execConfig.interactiveMode ?? 'IfAvailable';
     if (stdinPolicy == 'Always' && !isTTY) {
       throw new Error(`KubeConfig exec plugin wants a TTY, but stdin is not a TTY`);

--- a/lib/kubeconfig.ts
+++ b/lib/kubeconfig.ts
@@ -193,12 +193,12 @@ export class KubeConfigContext {
             if (expiresAt.valueOf() > Date.now()) {
               return `Bearer ${config['access-token']}`;
             } else throw new Error(
-              `TODO: GCP auth-provider token expired, use a kubectl command to refresh for now`);
+              `GCP "auth-provider" token expired, run a kubectl command to refresh. Or consider updating to "exec"`);
           } else throw new Error(
-            `TODO: GCP auth-provider lacks a cached token, use a kubectl command to refresh for now`);
+            `GCP "auth-provider" lacks a cached token, run a kubectl command to refresh. Or consider updating to "exec"`);
 
         default: throw new Error(
-          `TODO: this kubeconfig's auth-provider (${name}) isn't supported yet`);
+          `This kubeconfig's "auth-provider" (${name}) isn't supported. Consider updating to "exec"`);
       }
 
     } else if (this.user['exec']) {

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -80,11 +80,8 @@ export class KubeConfigRestClient implements RestClient {
       if (Deno.createHttpClient) {
         httpClient = Deno.createHttpClient({
           caCerts: serverTls ? [serverTls.serverCert] : [],
-          //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
-          certChain: tlsAuth?.userCert,
-          //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
+          //@ts-ignore-error deno unstable API. Not typed?
           cert: tlsAuth?.userCert,
-          privateKey: tlsAuth?.userKey,
           key: tlsAuth?.userKey,
         });
       } else if (tlsAuth) {

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -80,8 +80,11 @@ export class KubeConfigRestClient implements RestClient {
       if (Deno.createHttpClient) {
         httpClient = Deno.createHttpClient({
           caCerts: serverTls ? [serverTls.serverCert] : [],
+          //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
           certChain: tlsAuth?.userCert,
+          cert: tlsAuth?.userCert,
           privateKey: tlsAuth?.userKey,
+          key: tlsAuth?.userKey,
         });
       } else if (tlsAuth) {
         console.error('WARN: cannot use certificate-based auth without --unstable');

--- a/transports/via-kubeconfig.ts
+++ b/transports/via-kubeconfig.ts
@@ -82,6 +82,7 @@ export class KubeConfigRestClient implements RestClient {
           caCerts: serverTls ? [serverTls.serverCert] : [],
           //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
           certChain: tlsAuth?.userCert,
+          //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
           cert: tlsAuth?.userCert,
           privateKey: tlsAuth?.userKey,
           key: tlsAuth?.userKey,

--- a/tunnel-beta/examples/ws-exec-poc.ts
+++ b/tunnel-beta/examples/ws-exec-poc.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-env --allow-read --allow-net
+#!/usr/bin/env -S deno run --unstable-net --allow-env --allow-read --allow-net --cert=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
 import { WebsocketRestClient } from "../via-websocket.ts";
 

--- a/tunnel-beta/via-spdy-transport.ts
+++ b/tunnel-beta/via-spdy-transport.ts
@@ -21,11 +21,8 @@ export class SpdyEnabledRestClient extends KubeConfigRestClient {
       port: url.port ? parseInt(url.port) : 443,
       alpnProtocols: ['http/1.1'],
       caCerts: serverTls?.serverCert ? [serverTls.serverCert] : [],
-      //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
-      certChain: clientTls?.userCert,
-      //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
+      //@ts-ignore-error deno unstable API. Not typed?
       cert: clientTls?.userCert,
-      privateKey: clientTls?.userKey,
       key: clientTls?.userKey,
     });
 

--- a/tunnel-beta/via-spdy-transport.ts
+++ b/tunnel-beta/via-spdy-transport.ts
@@ -23,6 +23,7 @@ export class SpdyEnabledRestClient extends KubeConfigRestClient {
       caCerts: serverTls?.serverCert ? [serverTls.serverCert] : [],
       //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
       certChain: clientTls?.userCert,
+      //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
       cert: clientTls?.userCert,
       privateKey: clientTls?.userKey,
       key: clientTls?.userKey,

--- a/tunnel-beta/via-spdy-transport.ts
+++ b/tunnel-beta/via-spdy-transport.ts
@@ -21,8 +21,11 @@ export class SpdyEnabledRestClient extends KubeConfigRestClient {
       port: url.port ? parseInt(url.port) : 443,
       alpnProtocols: ['http/1.1'],
       caCerts: serverTls?.serverCert ? [serverTls.serverCert] : [],
+      //@ts-ignore-error deno unstable API. These were renamed at some point, we'll pass both.
       certChain: clientTls?.userCert,
+      cert: clientTls?.userCert,
       privateKey: clientTls?.userKey,
+      key: clientTls?.userKey,
     });
 
     const transport = await dialSpdyTunnel({

--- a/tunnel-beta/via-websocket.ts
+++ b/tunnel-beta/via-websocket.ts
@@ -9,6 +9,8 @@ import { KubeConfigRestClient } from "../transports/via-kubeconfig.ts";
  * WebSockets have various limits within the Kubernetes and Deno ecosystem,
  * but they work quite well in several situations and have good backpressure support.
  *
+ * * Run Deno with `--unstable-net` to enable the required WebSocketStream API.
+ *
  * * For most clusters, you'll need to have Deno trust the cluster CA.
  *   Otherwise you'll get an `UnknownIssuer` error.
  *   In-cluster, you just need to pass `--cert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
@@ -22,6 +24,7 @@ import { KubeConfigRestClient } from "../transports/via-kubeconfig.ts";
  *   (TODO: find or create Kubernetes ticket to track this)
  *
  * * stdin restricted for exec/attach due to lack of EOF signal.
+ *   Addressed in Kubernetes v1.29 via new `v5.channel.k8s.io` protocol.
  *   Upstream work: https://github.com/kubernetes/kubernetes/pull/119157
  */
 export class WebsocketRestClient extends KubeConfigRestClient {


### PR DESCRIPTION
Going to be looking forward since this library hasn't been having many changes so people with older denos should be ok staying on older versions. Canary CI is lined up with Deno v2.