### PR TITLE
Add support for relative paths in Kubeconfig

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,8 @@
-export { join as joinPath } from "https://deno.land/std@0.214.0/path/mod.ts";
+export {
+  dirname,
+  join as joinPath,
+  resolve as resolvePath,
+} from "https://deno.land/std@0.214.0/path/mod.ts";
 
 export { parse as parseYaml } from "https://deno.land/std@0.214.0/yaml/mod.ts";
 


### PR DESCRIPTION
It is possible to use paths relative to `.kube/` in `.kube/config`, and `kubectl` works with relative paths.

Because of this, some tools and scripts generate cluster configurations with relative paths, which breaks `deno-kubernetes_client`.

Example config:

```yaml
# .kube/config
apiVersion: v1
kind: Config
clusters:
- cluster:
    certificate-authority: tls/example/ca.crt
    server: https://192.168.100.101:6443
  name: example
users:
- name: example-admin
  user:
    client-certificate: tls/example/admin.crt
    client-key: tls/example/admin.key
```