### PR TITLE
Handle kubeconfig null for exec auth

### DIFF
--- a/lib/kubeconfig/context.ts
+++ b/lib/kubeconfig/context.ts
@@ -155,7 +155,7 @@ export class KubeConfigContext {
 
     // TODO: add nodejs impl
     const proc = new Deno.Command(execConfig.command, {
-      args: execConfig.args,
+      args: execConfig.args ?? [],
       stdin: req.spec.interactive ? 'inherit' : 'null',
       stdout: 'piped',
       stderr: 'inherit',


### PR DESCRIPTION
Saw kubeconfig putting explicit nulls into the exec config:

```yaml
- name: gke_...
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args: null
      command: gke-gcloud-auth-plugin
      env: null
      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following
        https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin
      interactiveMode: IfAvailable
      provideClusterInfo: true
```

Let's avoid using them.